### PR TITLE
Click the Allow Reacting option error

### DIFF
--- a/packages/rocketchat-channel-settings/client/views/channelSettings.coffee
+++ b/packages/rocketchat-channel-settings/client/views/channelSettings.coffee
@@ -198,7 +198,7 @@ Template.channelSettings.onCreated ->
 			canView: (room) => room.t isnt 'd' and room.ro
 			canEdit: (room) => RocketChat.authz.hasAllPermission('set-react-when-readonly', room._id)
 			save: (value, room) ->
-				Meteor.call 'saveRoomSettings', room._id, 'reactWhenReadOnly', value, (err, result) ->
+				Meteor.call 'saveRoomSettings', room._id, 'reactWhenReadOnly', value, (err, result) =>
 					return handleError err if err
 					toastr.success TAPi18n.__ 'React_when_read_only_changed_successfully'
 


### PR DESCRIPTION
TypeError: Cannot read property 'set' of undefined
 ChannelSettings.coffee Line 201
Should be "=>" instead of "->"
"@" changed，"@processing" is undefined

The details are important ^_^
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/core 

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #ISSUE_NUMBER

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->
